### PR TITLE
fix typo in paasify plan output

### DIFF
--- a/libexec/paasify-plan
+++ b/libexec/paasify-plan
@@ -4,7 +4,7 @@
 # Help: Prints the plan output from Terraform for the changes that would be applied to a given environment in its current state
 #
 #    -n    the name of the environment
-#  
+#
 
 source $_PAASIFY_ROOT/share/init-env
 
@@ -51,4 +51,4 @@ state_file=$env_dir/terraform.tfstate
 (cd $env_dir && TF_VAR_pivnet_token=$PAASIFY_PIVNET_TOKEN $TF_BIN plan -state=$state_file -input=false)
 
 echo ""
-echo "To apply this configuration use 'paasify plan -n $name'"
+echo "To apply this configuration use 'paasify apply -n $name'"


### PR DESCRIPTION
At the end of `paasify plan` it should output `paasify apply` and not `paasify plan` again.